### PR TITLE
Enable future-dated posts to fix blog 404s

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,5 +1,6 @@
-title: "Codex-Test Blog"
+title: "Pankaj's Blog"
 description: "A sample blog using GitHub Pages"
 theme: minima
+future: true
 plugins:
   - jekyll-feed


### PR DESCRIPTION
## Summary
- enable Jekyll's `future` option so posts dated ahead of today are generated and routed
- update the site title to "Pankaj's Blog"

## Testing
- bundle exec jekyll build

------
https://chatgpt.com/codex/tasks/task_e_68c896967920832396a484d655c134d1