### PR TITLE
Add blog index page to resolve blog 404

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,5 +1,8 @@
-title: "Codex-Test Blog"
+title: "Pankaj's Blog"
 description: "A sample blog using GitHub Pages"
 theme: minima
+future: true
+header_pages:
+  - blog.md
 plugins:
   - jekyll-feed

--- a/docs/blog.md
+++ b/docs/blog.md
@@ -1,0 +1,23 @@
+---
+layout: page
+title: Blog
+permalink: /blog/
+---
+
+Catch up on the latest posts from my work in data science and analytics.
+
+<ul class="post-list">
+  {%- for post in site.posts -%}
+  <li>
+    <span class="post-meta">{{ post.date | date: "%b %-d, %Y" }}</span>
+    <h3>
+      <a class="post-link" href="{{ post.url | relative_url }}">
+        {{ post.title | escape }}
+      </a>
+    </h3>
+    {%- if post.excerpt -%}
+    <p>{{ post.excerpt | strip_html | truncate: 160 }}</p>
+    {%- endif -%}
+  </li>
+  {%- endfor -%}
+</ul>


### PR DESCRIPTION
## Summary
- add a dedicated /blog/ index page that lists recent posts so the blog URL returns content
- expose the new page in the navigation menu so visitors can reach it easily

## Testing
- bundle exec jekyll build

------
https://chatgpt.com/codex/tasks/task_e_68c896967920832396a484d655c134d1