### PR TITLE
Replace blog nav text with LinkedIn icon

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,0 +1,36 @@
+<header class="site-header" role="banner">
+  <div class="wrapper">
+    <a class="site-title" rel="author" href="{{ "/" | relative_url }}">{{ site.title | escape }}</a>
+    {%- assign default_paths = site.pages | map: "path" -%}
+    {%- assign page_paths = site.header_pages | default: default_paths -%}
+    {%- assign titles_size = site.pages | map: 'title' | join: '' | size -%}
+    {%- if titles_size > 0 -%}
+      <nav class="site-nav" aria-label="Primary">
+        <input type="checkbox" id="nav-trigger" class="nav-trigger" />
+        <label for="nav-trigger">
+          <span class="menu-icon">
+            <svg viewBox="0 0 18 15" width="18" height="15" aria-hidden="true">
+              <path d="M18 1.484c0 .82-.665 1.484-1.484 1.484H1.484A1.484 1.484 0 0 1 0 1.484C0 .665.665 0 1.484 0h15.032C17.335 0 18 .665 18 1.484ZM18 7.5c0 .82-.665 1.484-1.484 1.484H1.484A1.484 1.484 0 0 1 0 7.5c0-.82.665-1.484 1.484-1.484h15.032C17.335 6.016 18 6.68 18 7.5Zm0 6.016c0 .82-.665 1.484-1.484 1.484H1.484A1.484 1.484 0 0 1 0 13.516c0-.82.665-1.484 1.484-1.484h15.032c.819 0 1.484.665 1.484 1.484Z" />
+            </svg>
+          </span>
+        </label>
+        <div class="trigger">
+          {%- for path in page_paths -%}
+            {%- assign my_page = site.pages | where: "path", path | first -%}
+            {%- if my_page -%}
+              {%- if my_page.url == "/blog/" -%}
+                <a class="page-link linkedin-link" href="https://www.linkedin.com/in/psharma13/" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn" title="LinkedIn">
+                  <svg class="icon icon-linkedin" role="img" viewBox="0 0 24 24" aria-hidden="true">
+                    <path fill="currentColor" d="M20.447 20.452h-3.554v-5.569c0-1.328-.024-3.037-1.852-3.037-1.853 0-2.136 1.447-2.136 2.942v5.664H9.351V9h3.414v1.561h.047c.476-.9 1.637-1.852 3.368-1.852 3.6 0 4.267 2.37 4.267 5.455v6.288ZM5.337 7.433a2.062 2.062 0 1 1 0-4.124 2.062 2.062 0 0 1 0 4.124Zm-1.777 13.019h3.554V9H3.56v11.452ZM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.226.792 24 1.771 24h20.451C23.2 24 24 23.226 24 22.271V1.73C24 .774 23.2 0 22.222 0h.003Z" />
+                  </svg>
+                </a>
+              {%- else -%}
+                <a class="page-link" href="{{ my_page.url | relative_url }}">{{ my_page.title | escape }}</a>
+              {%- endif -%}
+            {%- endif -%}
+          {%- endfor -%}
+        </div>
+      </nav>
+    {%- endif -%}
+  </div>
+</header>

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -1,0 +1,21 @@
+---
+---
+
+@import "minima";
+
+.site-nav .linkedin-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.5rem;
+}
+
+.site-nav .linkedin-link svg {
+  width: 1.5rem;
+  height: 1.5rem;
+}
+
+.site-nav .linkedin-link:focus-visible {
+  outline: 2px solid currentColor;
+  outline-offset: 2px;
+}

--- a/blog.md
+++ b/blog.md
@@ -6,6 +6,8 @@ permalink: /blog/
 
 Catch up on the latest posts from my work in data science and analytics.
 
+Connect with me on [LinkedIn](https://www.linkedin.com/in/psharma13/) for more updates and professional insights.
+
 <ul class="post-list">
   {%- for post in site.posts -%}
   <li>


### PR DESCRIPTION
## Summary
- override the site header to swap the blog navigation item for a LinkedIn icon that links to your profile
- add styling so the LinkedIn icon is sized and focusable consistently with the existing navigation

## Testing
- bundle exec jekyll build

------
https://chatgpt.com/codex/tasks/task_e_68d47af8db4c8323bf7cf95d87edb7ef